### PR TITLE
added fix to prevent testing bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ with the corresponding data from `@post`. We'll also use a different form helper
 
 <%= form_for @post do |f| %>
   <%= f.label 'Post Title' %><br>
-  <%= f.text_field :title %><br>
+  <%= f.text_field_tag :title %><br>
 
   <%= f.label 'Post Description' %><br>
-  <%= f.text_area :description %><br>
+  <%= f.text_area_tag :description %><br>
 
   <%= f.submit "Submit Post" %>
 <% end %>


### PR DESCRIPTION
The test will pass if the student follows the code updated in this commit instead of what is in the master branch:

The needed deviation from the readme being that we need to employ text_field_tag and _text_area_tag methods, instead of FormBuilder's _text_field_ and _text_area_ methods, in lines 113 && 116 of readme.

**There may be a better solution, the drawback here being that we are not using the FormBuilder object passed into the block by form_for.**

Else the test framework cannot find the input fields to fill them in.